### PR TITLE
Make sure disqus_identifier gets set if passed

### DIFF
--- a/vendor/assets/javascripts/disqus_rails.js.coffee
+++ b/vendor/assets/javascripts/disqus_rails.js.coffee
@@ -42,8 +42,8 @@ class @DisqusRails
       @callbacks.onInit = [->
         $(document).trigger "disqus:on_init"
       ]
-      @callbacks.onNewComment = [->
-        $(document).trigger "disqus:on_new_comment"
+      @callbacks.onNewComment = [ (comment) ->
+        $(document).trigger "disqus:on_new_comment", [comment]
       ]
       @callbacks.onPaginate = [->
         $(document).trigger "disqus:on_paginate"


### PR DESCRIPTION
Although the documentation says you can pass an identifier to `disqus_thread`, it didn't seem to actually load the correct thread for me. I had to add a `window.disqus_identifier` setter to get this to finally work.
